### PR TITLE
Simple role for installing a gitlab-runner in docker and registering it

### DIFF
--- a/provision/README.md
+++ b/provision/README.md
@@ -4,5 +4,31 @@
 
 ### docker
 
-`docker` role to automate the installation of the docker service in Fedora and Debian based distributions.
+`docker` role to automate the installation of the docker service in Fedora and Debian based distributions. It has been tested on Fedora 35 and Ubuntu 22.
 
+```
+$ ansible-playbook playbooks/docker/run.yaml -kK
+SSH password: 
+
+...
+```
+
+### gitlab-runner
+
+`gitlab-runner` role to register a a runner via the GitLab API. We require a token provided by GitLab to perform all the operations of the role.
+
+```
+$ ansible-playbook playbooks/gitlab-runner/run.yaml -kK
+SSH password: 
+
+...
+```
+
+We should modify the `vars/main.yml` file with the right token and URL:
+
+```
+$ cat roles/gitlab_runner/vars/main.yml 
+---
+gitlab_url: "http://gitlab.example.com"
+runner_registration_token: "token"
+```

--- a/provision/playbooks/gitlab-runner/run.yaml
+++ b/provision/playbooks/gitlab-runner/run.yaml
@@ -1,0 +1,5 @@
+---
+- hosts: all
+  become: true
+  roles:
+    - role: roles/gitlab_runner

--- a/provision/roles/gitlab_runner/defaults/main.yml
+++ b/provision/roles/gitlab_runner/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+gitlab_url: "https://gitlab.com/"
+runner_executor: "docker"
+runner_description: "Tagged runner"
+runner_tag_list: "tagged"
+run_untagged: "false"
+docker_image: "ubuntu22:latest"
+
+architecture_translation:
+  x86_64: amd64
+  amd64: amd64
+
+repository_architecture: "{{ architecture_translation[ansible_architecture] }}"
+gpg_public_key: "https://packages.gitlab.com/runner/gitlab-runner/gpgkey/runner-gitlab-runner-4C80FB51394521E9.pub.gpg"

--- a/provision/roles/gitlab_runner/tasks/main.yml
+++ b/provision/roles/gitlab_runner/tasks/main.yml
@@ -39,7 +39,7 @@
       when: ansible_distribution == 'Fedora'
 
 - name: Register runner in GitLab provided instance
-  command: |
+  ansible.builtin.command: |
     gitlab-runner register \
     --non-interactive \
     --url "{{ gitlab_url }}" \
@@ -55,6 +55,6 @@
   changed_when: register_output.rc != 0
 
 - name: Start runner
-  command: gitlab-runner start
+  ansible.builtin.command: gitlab-runner start
   register: runner_start_output
   changed_when: runner_start_output.rc != 0

--- a/provision/roles/gitlab_runner/tasks/main.yml
+++ b/provision/roles/gitlab_runner/tasks/main.yml
@@ -1,0 +1,60 @@
+---
+- name: Include variables based on distribution
+  ansible.builtin.include_vars:
+    file: "{{ ansible_distribution | lower }}.yaml"
+
+- name: Check if required variables are not empty
+  ansible.builtin.fail:
+    msg: "The variable {{ item }} is empty"
+  when: item | length == 0
+  loop:
+    - gitlab_url
+    - runner_registration_token
+
+- name: Add GPG gitlab runner public repository key
+  block:
+    - name: Add GPG gitlab runner Debian/Ubuntu
+      ansible.builtin.get_url:
+        url: "{{ gpg_public_key }}"
+        dest: /etc/apt/trusted.gpg.d/gitlab_runner.asc
+        mode: '0644'
+        force: true
+      when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+    - name: Add GPG gitlab runner Fedora
+      ansible.builtin.rpm_key:
+        key: "{{ gpg_public_key }}"
+        state: present
+      when: ansible_distribution == 'Fedora'
+
+- name: Install gitlab-runner from remote URL
+  block:
+    - name: Install deb package
+      ansible.builtin.apt:
+        deb: "{{ gitlab_runner_download_base_url }}"
+      when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+    - name: Install rpm package
+      ansible.builtin.yum:
+        name: "{{ gitlab_runner_download_base_url }}"
+        state: present
+      when: ansible_distribution == 'Fedora'
+
+- name: Register runner in GitLab provided instance
+  command: |
+    gitlab-runner register \
+    --non-interactive \
+    --url "{{ gitlab_url }}" \
+    --registration-token "{{ runner_registration_token }}" \
+    --executor "{{ runner_executor }}" \
+    --docker-image "{{ docker_image }}" \
+    --description "{{ runner_description }}" \
+    --tag-list "{{ runner_tag_list }}" \
+    --run-untagged="{{ run_untagged }}" \
+    --locked="true" \
+    --access-level="ref_protected"
+  register: register_output
+  changed_when: register_output.rc != 0
+
+- name: Start runner
+  command: gitlab-runner start
+  register: runner_start_output
+  changed_when: runner_start_output.rc != 0

--- a/provision/roles/gitlab_runner/vars/fedora.yaml
+++ b/provision/roles/gitlab_runner/vars/fedora.yaml
@@ -1,0 +1,2 @@
+---
+gitlab_runner_download_base_url: "https://gitlab-runner-downloads.s3.amazonaws.com/latest/rpm/gitlab-runner_{{ repository_architecture }}.rpm"

--- a/provision/roles/gitlab_runner/vars/main.yml
+++ b/provision/roles/gitlab_runner/vars/main.yml
@@ -1,0 +1,3 @@
+---
+gitlab_url: "http://gitlab.example.com"
+runner_registration_token: "token"

--- a/provision/roles/gitlab_runner/vars/ubuntu.yaml
+++ b/provision/roles/gitlab_runner/vars/ubuntu.yaml
@@ -1,0 +1,2 @@
+---
+gitlab_runner_download_base_url: "https://gitlab-runner-downloads.s3.amazonaws.com/latest/deb/gitlab-runner_{{ repository_architecture }}.deb"


### PR DESCRIPTION
- Created a new role to install gitlab-runner package and register it in a gitlab instance
    - Tasks:
        - Add the required variables
        - Add the public gitlab-runner GPG key
        - Add the repository based on the architecture
        - Install gitlab-runner package
        - Registering a runner
        - Start runner

- Added two instances in the inventory. One with Ubuntu 22 (at the same time with a local GitLab instance running in docker) and other with Fedora 35 and executed the playbook:

```
[2022-11-11 16:37:26] {afuscoar@afuscoar} (~/.Redhat/Projects/github/toolbox/provision) (feature/add-gitlab-runner-install-role)$ -> ansible-playbook playbooks/gitlab-runner/run.yaml -kK 
SSH password: 
BECOME password[defaults to SSH password]: 

PLAY [all] *************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************************************************************************************************************************
ok: [192.168.122.104]
ok: [192.168.122.151]

TASK [gitlab_runner : Include variables based on distribution] *********************************************************************************************************************************************************************
ok: [192.168.122.104]
ok: [192.168.122.151]

TASK [gitlab_runner : Check if required variables are not empty] *******************************************************************************************************************************************************************
skipping: [192.168.122.104] => (item=gitlab_url) 
skipping: [192.168.122.104] => (item=runner_registration_token) 
skipping: [192.168.122.151] => (item=gitlab_url) 
skipping: [192.168.122.151] => (item=runner_registration_token) 

TASK [gitlab_runner : Add GPG gitlab runner Debian/Ubuntu] *************************************************************************************************************************************************************************
skipping: [192.168.122.151]
ok: [192.168.122.104]

TASK [gitlab_runner : Add GPG gitlab runner Fedora] ********************************************************************************************************************************************************************************
skipping: [192.168.122.104]
ok: [192.168.122.151]

TASK [gitlab_runner : Install deb package] *****************************************************************************************************************************************************************************************
skipping: [192.168.122.151]
ok: [192.168.122.104]

TASK [gitlab_runner : Install rpm package] *****************************************************************************************************************************************************************************************
skipping: [192.168.122.104]
ok: [192.168.122.151]

TASK [gitlab_runner : Register runner in GitLab provided instance] *****************************************************************************************************************************************************************
ok: [192.168.122.104]
ok: [192.168.122.151]

TASK [gitlab_runner : Start runner] ************************************************************************************************************************************************************************************************
ok: [192.168.122.104]
ok: [192.168.122.151]

PLAY RECAP *************************************************************************************************************************************************************************************************************************
192.168.122.104            : ok=6    changed=0    unreachable=0    failed=0    skipped=3    rescued=0    ignored=0   
192.168.122.151            : ok=6    changed=0    unreachable=0    failed=0    skipped=3    rescued=0    ignored=0   
```
![image](https://user-images.githubusercontent.com/59370927/201448185-191eaafe-b3b9-44bf-860c-7f5d7355f76f.png)


**Note**: I wasn't able to use the [gitlab_runner module](https://docs.ansible.com/ansible/latest/collections/community/general/gitlab_runner_module.html) of ansible. It is registering the runner but it's giving the warning `Runner has never contacted this instance`. I can execute `gitlab-runner run and start` but in this case I'll need `gitlab-runner` service provided by the package installed so it's duplication. I prefer to take advantage of this package and open an issue and ask for the possibility of add `run` and `start` options to the module.

![image](https://user-images.githubusercontent.com/59370927/201448339-40f674cf-2bc4-4fc7-ad2b-7c2da7f23219.png)
