### PR TITLE
Two tiny improves to EoD stuff

### DIFF
--- a/EoD-stuff/find-zuul-jobs-failures.py
+++ b/EoD-stuff/find-zuul-jobs-failures.py
@@ -102,6 +102,12 @@ def get_builds() -> list:
             for pipeline in PIPELINES:
                 for job in JOBS:
                     build = get_last_build(project, branch, pipeline, job)
+                    date = build.get('start_time', '')
+
+                    if date and (datetime.now()
+                                 - datetime.fromisoformat(date)).days > 14:
+                        build['result'] = '---'
+                        build['log_url'] = ''
 
                     builds.append(Build(
                         project=project,

--- a/EoD-stuff/find-zuul-jobs-failures.py
+++ b/EoD-stuff/find-zuul-jobs-failures.py
@@ -197,6 +197,8 @@ def find_failure_reason(url: str):
 
 
 def get_bad_results(builds: list[Build]) -> dict:
+    successes = sum([build.result == 'SUCCESS' for build in builds])
+
     builds = [build for build in builds
               if (build.result not in ('SUCCESS', '---')
                   and build.log_url != '')]
@@ -222,7 +224,8 @@ def get_bad_results(builds: list[Build]) -> dict:
         i += 1
         progress(i, end)
 
-    print('Number of failed builds:', len(results))
+    failures = len(results)
+    print('Number of failed builds:', failures, '/', failures + successes)
 
     return results
 


### PR DESCRIPTION
Display the number of all meaningful results

> Right now there is only number of failures displayed
> in summary, but to have some better context we want
> to know how many builds were recently triggered.

Ignore old results

> If there are builds in weekly pipeline older than 14 days
> then such job is no more interesting for us (probably was
> deleted and we do not monitor it anymore).